### PR TITLE
Add challenge and profile routes

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,9 @@ const morgan = require('morgan');
 const rateLimit = require('express-rate-limit');
 require('dotenv').config();
 
+const challengeRoutes = require('./routes/challengeRoutes');
+const profileRoutes = require('./routes/profileRoutes');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -44,6 +47,8 @@ app.get('/health', (req, res) => {
 // app.use('/api/auth', require('./routes/auth'));
 // app.use('/api/perspectives', require('./routes/perspectives'));
 // app.use('/api/users', require('./routes/users'));
+app.use('/challenge', challengeRoutes);
+app.use('/profile', profileRoutes);
 
 // 404 handler
 app.use('*', (req, res) => {

--- a/backend/tests/profile.test.js
+++ b/backend/tests/profile.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const app = require('../src/server');
+
+describe('Profile Routes', () => {
+  test('GET /profile should return 200', async () => {
+    const res = await request(app).get('/profile');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({});
+  });
+
+  test('GET /profile/echo-score should return echoScore', async () => {
+    const res = await request(app).get('/profile/echo-score');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('echoScore');
+  });
+});


### PR DESCRIPTION
## Summary
- import challenge/profile routers in the express server
- mount them under `/challenge` and `/profile`
- add tests for profile endpoints

## Testing
- `npm test` *(fails: jest not found)*