### PR TITLE
Add backend config module

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,0 +1,41 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export interface DatabaseSettings {
+  client: string;
+  host: string;
+  port: number;
+  name: string;
+  user: string;
+  password: string;
+  ssl: boolean;
+}
+
+export interface GeneralSettings {
+  env: string;
+  port: number;
+}
+
+export interface Config {
+  database: DatabaseSettings;
+  general: GeneralSettings;
+}
+
+const config: Config = {
+  database: {
+    client: process.env.DB_CLIENT || 'pg',
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432', 10),
+    name: process.env.DB_NAME || 'perspective_db',
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASSWORD || '',
+    ssl: process.env.DB_SSL === 'true',
+  },
+  general: {
+    env: process.env.NODE_ENV || 'development',
+    port: parseInt(process.env.PORT || '3000', 10),
+  },
+};
+
+export default config;

--- a/backend/src/index.d.ts
+++ b/backend/src/index.d.ts
@@ -1,0 +1,22 @@
+export interface DatabaseSettings {
+  client: string;
+  host: string;
+  port: number;
+  name: string;
+  user: string;
+  password: string;
+  ssl: boolean;
+}
+
+export interface GeneralSettings {
+  env: string;
+  port: number;
+}
+
+export interface Config {
+  database: DatabaseSettings;
+  general: GeneralSettings;
+}
+
+declare const config: Config;
+export default config;


### PR DESCRIPTION
## Summary
- provide a `config.ts` in backend to centralize environment settings
- supply typings in `index.d.ts`
- `db/index.ts` already imports `../config`

## Testing
- `npm test` *(fails: Cannot find module 'bcryptjs' and others)*