### PR TITLE
Document pod install fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots/**/*.png
 fastlane/test_output
+
+# Build outputs
+dist/

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -71,3 +71,4 @@
 - Ensure all prerequisites are installed
 - Check that ports 3000 (backend) and 8080 (mobile) are available
 - Verify environment variables are set correctly
+- If Xcode reports `The sandbox is not in sync with the Podfile.lock`, open a terminal, change to the `ios` directory and run `pod install`. Then open `Perspective.xcworkspace` instead of the Xcode project file.


### PR DESCRIPTION
## Summary
- ignore TypeScript build output
- clarify that running `pod install` resolves the "sandbox is not in sync" Xcode error

## Testing
- `npm test` *(fails: Cannot find module 'knex' or its corresponding type declarations)*