### PR TITLE
Fix imports and update Node URL usage

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-const challengeService = require('../services/challengeService').default;
+import challengeService from '../services/challengeService';
 import { AuthenticatedRequest } from '../middleware/auth';
 
 // GET /challenge/today

--- a/backend/src/services/contentCurationService.ts
+++ b/backend/src/services/contentCurationService.ts
@@ -1,6 +1,7 @@
 import Content, { BiasRating, ContentType, IContent, INewsSource } from '../models/Content';
 import newsIntegrationService from './newsIntegrationService';
 import db from '../db';
+import { URL } from 'url';
 
 interface ContentValidation {
   isValid: boolean;


### PR DESCRIPTION
## Summary
- use ES module import for challengeService
- import URL from `url` for content curation service

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm test` *(fails to run tests: jest/ts type errors)*