### PR TITLE
Implement profile data loading

### DIFF
--- a/ios/Perspective/Services/APIService.swift
+++ b/ios/Perspective/Services/APIService.swift
@@ -148,6 +148,15 @@ class APIService: ObservableObject {
             responseType: [LeaderboardEntry].self
         )
     }
+
+    func getAchievements() -> AnyPublisher<[Achievement], APIError> {
+        return makeAuthenticatedRequest(
+            endpoint: "/profile/achievements",
+            method: "GET",
+            body: Optional<String>.none,
+            responseType: [Achievement].self
+        )
+    }
     
     // MARK: - Echo Score
     


### PR DESCRIPTION
## Summary
- fetch earned achievements and challenge stats in `ProfileViewModel`
- expose new API endpoint to get achievements
- show profile stats and earned achievements in ProfileView

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: cannot find Jest types)*

------
https://chatgpt.com/codex/tasks/task_e_683a203da7d48331a4c27fc6ee125833