### PR TITLE
Add challenge management endpoints

### DIFF
--- a/backend/src/controllers/challengeController.ts
+++ b/backend/src/controllers/challengeController.ts
@@ -186,4 +186,49 @@ export const getChallengeHistory = async (req: any, res: any) => {
   }
 };
 
+// POST /challenge
+export const createChallenge = async (req: Request, res: Response) => {
+  try {
+    const challenge = await challengeService.createChallenge(req.body);
+    res.status(201).json(challenge);
+  } catch (error) {
+    console.error('Error creating challenge:', error);
+    res.status(500).json({ error: 'Failed to create challenge' });
+  }
+};
+
+// PUT /challenge/:id
+export const updateChallenge = async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id);
+    const updated = await challengeService.updateChallenge(id, req.body);
+
+    if (!updated) {
+      return res.status(404).json({ error: 'Challenge not found' });
+    }
+
+    res.json(updated);
+  } catch (error) {
+    console.error('Error updating challenge:', error);
+    res.status(500).json({ error: 'Failed to update challenge' });
+  }
+};
+
+// DELETE /challenge/:id
+export const deleteChallenge = async (req: Request, res: Response) => {
+  try {
+    const id = parseInt(req.params.id);
+    const deleted = await challengeService.deleteChallenge(id);
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Challenge not found' });
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting challenge:', error);
+    res.status(500).json({ error: 'Failed to delete challenge' });
+  }
+};
+
 // TODO: Add more endpoints as needed

--- a/backend/src/routes/challengeRoutes.ts
+++ b/backend/src/routes/challengeRoutes.ts
@@ -7,7 +7,10 @@ import {
   getAdaptiveChallenge,
   getAdaptiveRecommendations,
   getUserProgress,
-  getChallengeHistory
+  getChallengeHistory,
+  createChallenge,
+  updateChallenge,
+  deleteChallenge
 } from "../controllers/challengeController";
 import { authenticateToken } from "../middleware/auth";
 
@@ -24,5 +27,10 @@ router.get("/stats", authenticateToken, getChallengeStats);
 
 // Public routes
 router.get("/leaderboard", getLeaderboard);
+
+// Management routes
+router.post("/", authenticateToken, createChallenge);
+router.put("/:id", authenticateToken, updateChallenge);
+router.delete("/:id", authenticateToken, deleteChallenge);
 
 export default router;

--- a/backend/src/services/challengeService.ts
+++ b/backend/src/services/challengeService.ts
@@ -42,8 +42,45 @@ export class ChallengeService {
     const challenge = await db('challenges')
       .where('id', challengeId)
       .first();
-    
+
     return challenge || null;
+  }
+
+  /**
+   * Create a new challenge
+   */
+  async createChallenge(data: Partial<Challenge>): Promise<Challenge> {
+    const [challenge] = await db('challenges')
+      .insert(data)
+      .returning('*');
+
+    return challenge;
+  }
+
+  /**
+   * Update an existing challenge
+   */
+  async updateChallenge(id: number, data: Partial<Challenge>): Promise<Challenge | null> {
+    const [updated] = await db('challenges')
+      .where('id', id)
+      .update({
+        ...data,
+        updated_at: db.fn.now()
+      })
+      .returning('*');
+
+    return updated || null;
+  }
+
+  /**
+   * Delete a challenge
+   */
+  async deleteChallenge(id: number): Promise<boolean> {
+    const deleted = await db('challenges')
+      .where('id', id)
+      .del();
+
+    return deleted > 0;
   }
 
   /**


### PR DESCRIPTION
## Summary
- implement CRUD methods in challengeService
- add create, update, delete handlers in challengeController
- register challenge management routes

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683a2043c3a8833188b220fd325742f5