### PR TITLE
Implement avatar upload endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,7 @@ fastlane/test_output
 
 # Build outputs
 dist/
+backend/uploads/
 
 # SQLite databases
 *.sqlite

--- a/backend/src/controllers/profileController.ts
+++ b/backend/src/controllers/profileController.ts
@@ -268,15 +268,24 @@ export class ProfileController {
         });
       }
 
-      // This is a placeholder for avatar upload functionality
-      // In a real implementation, you'd handle file upload with multer or similar
-      // and upload to a storage service like AWS S3
-      
-      res.status(501).json({
-        error: {
-          code: 'NOT_IMPLEMENTED',
-          message: 'Avatar upload not yet implemented'
-        }
+      if (!req.file) {
+        return res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'No avatar file uploaded'
+          }
+        });
+      }
+
+      const fileUrl = `${req.protocol}://${req.get('host')}/uploads/avatars/${req.file.filename}`;
+
+      const updatedUser = await UserService.updateProfile(req.user.id, { avatar_url: fileUrl });
+
+      const { password_hash: _, ...userWithoutPassword } = updatedUser;
+
+      res.json({
+        user: userWithoutPassword,
+        message: 'Avatar uploaded successfully'
       });
 
     } catch (error) {

--- a/backend/src/middleware/upload.ts
+++ b/backend/src/middleware/upload.ts
@@ -1,0 +1,30 @@
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+const avatarsDir = path.resolve(__dirname, '..', '..', 'uploads', 'avatars');
+fs.mkdirSync(avatarsDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, avatarsDir);
+  },
+  filename: (_req, file, cb) => {
+    const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const ext = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${ext}`);
+  }
+});
+
+const fileFilter = (_req: any, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+  if (!file.mimetype.startsWith('image/')) {
+    return cb(new Error('Only image files are allowed'));
+  }
+  cb(null, true);
+};
+
+export const avatarUpload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter
+}).single('avatar');

--- a/backend/src/routes/profileRoutes.ts
+++ b/backend/src/routes/profileRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { ProfileController } from "../controllers/profileController";
 import { authenticateToken } from "../middleware/auth";
+import { avatarUpload } from "../middleware/upload";
 
 const router = Router();
 
@@ -14,6 +15,6 @@ router.put("/", ProfileController.updateProfile);
 // Profile-specific endpoints
 router.get("/echo-score", ProfileController.getEchoScore);
 router.get("/stats", ProfileController.getProfileStats);
-router.post("/avatar", ProfileController.uploadAvatar);
+router.post("/avatar", avatarUpload, ProfileController.uploadAvatar);
 
 export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import helmet from 'helmet';
 import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import dotenv from 'dotenv';
+import path from 'path';
 import requestLogger from './middleware/requestLogger';
 import errorHandler from './middleware/errorHandler';
 
@@ -99,6 +100,9 @@ app.use(express.json({
   }
 }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+// Serve uploaded files
+app.use('/uploads', express.static(path.join(__dirname, '../uploads')));
 
 // Request ID and timing middleware
 app.use(requestLogger);

--- a/backend/src/types/express.d.ts
+++ b/backend/src/types/express.d.ts
@@ -6,5 +6,6 @@ declare namespace Express {
       username?: string;
       role?: string;
     };
+    file?: Express.Multer.File;
   }
-} 
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,6 +39,7 @@ Authorization: Bearer <your-token>
 
 - `GET /users/profile` - Get user profile
 - `PUT /users/profile` - Update user profile
+- `POST /users/avatar` - Upload user avatar
 - `GET /users/:id` - Get user by ID
 
 ### Echo Score


### PR DESCRIPTION
## Summary
- implement `avatarUpload` middleware using Multer for storing avatars
- expose `/uploads` as a static directory
- wire middleware into profile routes
- add avatar upload logic to profile controller
- document new `/users/avatar` endpoint
- ignore uploaded files

## Testing
- `npm test` *(fails: Cannot find module '@types/node')*

------
https://chatgpt.com/codex/tasks/task_e_683a2061c6108331a489cb89247bc7d3