### PR TITLE
Hook profile stats view to API

### DIFF
--- a/ios/Perspective/Models/User.swift
+++ b/ios/Perspective/Models/User.swift
@@ -114,11 +114,22 @@ struct GoogleSignInRequest: Codable {
     }
 }
 
-struct UserStatistics {
+struct UserStatistics: Codable {
     let totalChallengesCompleted: Int
     let currentStreak: Int
-    let longestStreak: Int
+    let longestStreak: Int?
     let averageAccuracy: Double
     let totalTimeSpent: Int // in minutes
-    let joinDate: Date
+    let memberSince: Date
+    let lastActivity: Date?
+
+    private enum CodingKeys: String, CodingKey {
+        case totalChallengesCompleted
+        case currentStreak
+        case longestStreak
+        case averageAccuracy
+        case totalTimeSpent
+        case memberSince
+        case lastActivity
+    }
 }

--- a/ios/Perspective/Services/APIService.swift
+++ b/ios/Perspective/Services/APIService.swift
@@ -168,7 +168,16 @@ class APIService: ObservableObject {
             responseType: [EchoScoreHistory].self
         )
     }
-    
+
+    func getProfileStats() -> AnyPublisher<UserStatistics, APIError> {
+        return makeAuthenticatedRequest(
+            endpoint: "/profile/stats",
+            method: "GET",
+            body: Optional<String>.none,
+            responseType: UserStatistics.self
+        )
+    }
+
     // MARK: - Private Methods
     
     private func handleAuthSuccess(_ response: AuthResponse) {


### PR DESCRIPTION
## Summary
- add `Codable` conformance for `UserStatistics`
- expose `getProfileStats` on `APIService`
- fetch profile statistics with new `ProfileStatisticsViewModel`
- display API data in `ProfileStatisticsView`

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683a2073b1f88331bf1b6c2833147c61