### PR TITLE
Switch backend to bcrypt

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,7 @@
         "@types/node-cron": "^3.0.11",
         "aws-sdk": "^2.1490.0",
         "axios": "^1.9.0",
-        "bcryptjs": "^2.4.3",
+        "bcrypt": "^5.1.1",
         "commander": "^14.0.0",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@types/axios": "^0.9.36",
-        "@types/bcryptjs": "^2.4.6",
+        "@types/bcrypt": "^5.0.0",
         "@types/cors": "^2.8.18",
         "@types/express": "^4.17.22",
         "@types/helmet": "^0.0.48",
@@ -1439,10 +1439,10 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
-      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+    "node_modules/@types/bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-",
       "dev": true,
       "license": "MIT"
     },
@@ -2346,10 +2346,10 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
-    "node_modules/bcryptjs": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+    "node_modules/bcrypt": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
+      "integrity": "sha512-",
       "license": "MIT"
     },
     "node_modules/bignumber.js": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,7 @@
     "@types/node-cron": "^3.0.11",
     "aws-sdk": "^2.1490.0",
     "axios": "^1.9.0",
-    "bcryptjs": "^2.4.3",
+    "bcrypt": "^5.1.1",
     "commander": "^14.0.0",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@types/axios": "^0.9.36",
-    "@types/bcryptjs": "^2.4.6",
+    "@types/bcrypt": "^5.0.0",
     "@types/cors": "^2.8.18",
     "@types/express": "^4.17.22",
     "@types/helmet": "^0.0.48",

--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import bcrypt from 'bcryptjs';
+import bcrypt from 'bcrypt';
 import { OAuth2Client } from 'google-auth-library';
 import { generateToken, AuthenticatedRequest } from '../middleware/auth';
 import { CreateUserRequest, LoginRequest, User } from '../models/User';

--- a/backend/tests/passwordHash.test.ts
+++ b/backend/tests/passwordHash.test.ts
@@ -1,0 +1,11 @@
+import bcrypt from 'bcrypt';
+
+describe('Password hashing using bcrypt', () => {
+  it('should hash and verify a password', async () => {
+    const password = 'secret123';
+    const hash = await bcrypt.hash(password, 10);
+    expect(hash).not.toBe(password);
+    const matches = await bcrypt.compare(password, hash);
+    expect(matches).toBe(true);
+  });
+});

--- a/backend/tests/passwordHash.test.ts
+++ b/backend/tests/passwordHash.test.ts
@@ -1,9 +1,11 @@
 import bcrypt from 'bcrypt';
 
+const SALT_ROUNDS = 10;
+
 describe('Password hashing using bcrypt', () => {
   it('should hash and verify a password', async () => {
     const password = 'secret123';
-    const hash = await bcrypt.hash(password, 10);
+    const hash = await bcrypt.hash(password, SALT_ROUNDS);
     expect(hash).not.toBe(password);
     const matches = await bcrypt.compare(password, hash);
     expect(matches).toBe(true);


### PR DESCRIPTION
## Summary
- use `bcrypt` instead of `bcryptjs`
- update auth controller import
- add test covering bcrypt hashing

## Testing
- `npm test` *(fails: Cannot find module 'dotenv' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683a2142d65c8331ac20d396dc5eae93