### PR TITLE
Enforce JWT_SECRET at startup

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -10,25 +10,30 @@ export interface AuthenticatedRequest extends Request {
 }
 
 export const authenticateToken = (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not defined');
+  }
+
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
 
   if (!token) {
-    return res.status(401).json({ 
-      error: { 
-        code: 'UNAUTHORIZED', 
-        message: 'Access token required' 
-      } 
+    return res.status(401).json({
+      error: {
+        code: 'UNAUTHORIZED',
+        message: 'Access token required'
+      }
     });
   }
 
-  jwt.verify(token, process.env.JWT_SECRET || 'your-secret-key', (err: any, user: any) => {
+  jwt.verify(token, secret, (err: any, user: any) => {
     if (err) {
-      return res.status(403).json({ 
-        error: { 
-          code: 'FORBIDDEN', 
-          message: 'Invalid or expired token' 
-        } 
+      return res.status(403).json({
+        error: {
+          code: 'FORBIDDEN',
+          message: 'Invalid or expired token'
+        }
       });
     }
 
@@ -38,13 +43,18 @@ export const authenticateToken = (req: AuthenticatedRequest, res: Response, next
 };
 
 export const generateToken = (user: { id: number; email: string; username: string }): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not defined');
+  }
+
   return jwt.sign(
-    { 
-      id: user.id, 
-      email: user.email, 
-      username: user.username 
+    {
+      id: user.id,
+      email: user.email,
+      username: user.username
     },
-    process.env.JWT_SECRET || 'your-secret-key',
+    secret,
     { expiresIn: '7d' }
   );
-}; 
+};

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -18,6 +18,11 @@ import contentIngestionScheduler from './services/contentIngestionScheduler';
 
 dotenv.config();
 
+if (!process.env.JWT_SECRET) {
+  console.error('JWT_SECRET environment variable is required');
+  process.exit(1);
+}
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- require `JWT_SECRET` in auth middleware
- exit server startup if `JWT_SECRET` is not set

## Testing
- `npm -C backend run lint` *(fails: couldn't find eslint config)*
- `npm -C backend test` *(fails: cannot find modules during build)*

------
https://chatgpt.com/codex/tasks/task_e_683a2159fbc483319dafa343b3e73c4d