### PR TITLE
Add env_file usage for backend compose

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,7 @@ DB_NAME=perspective_dev               # Database name for development
 DB_NAME_TEST=perspective_test         # Database name for testing
 DB_USER=postgres                      # Database username
 DB_PASSWORD=password                  # Database password (change in production!)
+# Used by docker-compose for both app and postgres services
 DB_SSL=false                          # Enable SSL for database connection (true/false)
 
 # Production Database URL (for services like Heroku, Render, etc.)
@@ -20,6 +21,7 @@ DB_SSL=false                          # Enable SSL for database connection (true
 
 # Authentication & Security
 JWT_SECRET=your-super-secret-jwt-key  # JWT secret for token signing (MUST change in production!)
+# Used by docker-compose for the app service
 
 # CORS Configuration
 CORS_ORIGIN=http://localhost:3000     # Allowed CORS origin (update for production)

--- a/backend/README.md
+++ b/backend/README.md
@@ -58,7 +58,8 @@ Node.js Express backend API server for the Perspective App providing authenticat
 2. Set up environment variables:
    ```bash
    cp .env.example .env
-   # Edit .env with your configuration
+   # Edit .env with your configuration.
+   # At minimum set values for DB_PASSWORD and JWT_SECRET used by Docker Compose
    ```
 
 3. Start PostgreSQL (using Docker):
@@ -116,6 +117,10 @@ docker-compose up
 # Run in production mode
 docker-compose -f docker-compose.prod.yml up
 ```
+
+`docker-compose.yml` now loads `DB_PASSWORD` and `JWT_SECRET` from a `.env` file
+specified with `env_file`. Copy `backend/.env.example` to `.env` and update
+these values before running Docker Compose.
 
 ## Environment Variables
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   app:
     build: .
+    env_file:
+      - .env
     ports:
       - "3000:3000"
     environment:
@@ -11,8 +13,8 @@ services:
       - DB_PORT=5432
       - DB_NAME=perspective_db
       - DB_USER=postgres
-      - DB_PASSWORD=password
-      - JWT_SECRET=your-super-secret-jwt-key
+      - DB_PASSWORD=${DB_PASSWORD}
+      - JWT_SECRET=${JWT_SECRET}
       - PORT=3000
     depends_on:
       - postgres
@@ -27,7 +29,7 @@ services:
     environment:
       - POSTGRES_DB=perspective_db
       - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=password
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
## Summary
- add notes for DB_PASSWORD and JWT_SECRET in `.env.example`
- load variables from `.env` in `docker-compose.yml`
- document env_file setup in backend README

## Testing
- `npm test` *(fails: Cannot find name 'expect')*


------
https://chatgpt.com/codex/tasks/task_e_683a213e104883319dba677b2bd3950f