### PR TITLE
Use randomUUID in request logger

### DIFF
--- a/backend/src/middleware/requestLogger.ts
+++ b/backend/src/middleware/requestLogger.ts
@@ -1,7 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
 
 const requestLogger = (req: Request, res: Response, next: NextFunction): void => {
-  const requestId = Math.random().toString(36).substring(2, 15);
+  const requestId = randomUUID();
   (req as any).headers['x-request-id'] = requestId;
   res.setHeader('X-Request-ID', requestId);
 


### PR DESCRIPTION
## Summary
- switch to `crypto.randomUUID()` for request IDs

## Testing
- `npm test` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_683a213326b0833199cffccfdeb6e6b1