### PR TITLE
Update API configuration and token storage

### DIFF
--- a/ios/Perspective/Perspective/Info.plist
+++ b/ios/Perspective/Perspective/Info.plist
@@ -12,6 +12,8 @@
     <string>1.0</string>
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
+    <key>API_BASE_URL</key>
+    <string>https://example.com/api</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleInfoDictionaryVersion</key>

--- a/ios/README.md
+++ b/ios/README.md
@@ -12,7 +12,8 @@ directory now contains the sole maintained iOS implementation.
 - SwiftUI for modern UI components
 - MVVM architecture
 - Alamofire for networking
-- Keychain for secure storage
+- KeychainAccess for secure token storage
+- Configurable API base URL via `Info.plist`
 
 ## Build Requirements
 
@@ -38,12 +39,14 @@ directory now contains the sole maintained iOS implementation.
    pod install
    ```
 
-4. Open the workspace in Xcode:
+4. Update `API_BASE_URL` in `Perspective/Info.plist` to point to your backend server.
+
+5. Open the workspace in Xcode:
    ```bash
    open Perspective.xcworkspace
    ```
 
-5. Build and run the project
+6. Build and run the project
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- read API base URL from `Info.plist`
- store auth tokens using KeychainAccess
- document API configuration and keychain usage

## Testing
- `npm test` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_683a213959d08331872c0bc46a5ef8a8